### PR TITLE
Add edit feature for events and reminders

### DIFF
--- a/HaruView/App/AppDI.swift
+++ b/HaruView/App/AppDI.swift
@@ -49,9 +49,17 @@ final class DIContainer {
     func makeAddEventUseCase() -> AddEventUseCase {
         AddEventUseCase(repo: eventKitRepository)
     }
+
+    func makeEditEventUseCase() -> EditEventUseCase {
+        EditEventUseCase(repo: eventKitRepository)
+    }
     
     func makeAddReminderUseCase() -> AddReminderUseCase {
         AddReminderUseCase(repo: eventKitRepository)
+    }
+
+    func makeEditReminderUseCase() -> EditReminderUseCase {
+        EditReminderUseCase(repo: eventKitRepository)
     }
     
     func makeDeleteEventUseCase() -> DeleteObjectUseCase {
@@ -95,6 +103,20 @@ final class DIContainer {
     func makeAddSheetVM() -> AddSheetViewModel {
         AddSheetViewModel(addEvent: makeAddEventUseCase(),
                           addReminder: makeAddReminderUseCase())
+    }
+
+    @MainActor
+    func makeEditSheetVM(event: Event) -> EditSheetViewModel {
+        EditSheetViewModel(event: event,
+                           editEvent: makeEditEventUseCase(),
+                           editReminder: makeEditReminderUseCase())
+    }
+
+    @MainActor
+    func makeEditSheetVM(reminder: Reminder) -> EditSheetViewModel {
+        EditSheetViewModel(reminder: reminder,
+                           editEvent: makeEditEventUseCase(),
+                           editReminder: makeEditReminderUseCase())
     }
 }
 

--- a/HaruView/Data/EventKitRepository.swift
+++ b/HaruView/Data/EventKitRepository.swift
@@ -111,6 +111,10 @@ final class EventKitRepository: EventRepositoryProtocol, ReminderRepositoryProto
     func add(_ input: ReminderInput) async -> Result<Void, TodayBoardError> {
         service.addReminder(input)
     }
+
+    func update(_ edit: ReminderEdit) async -> Result<Void, TodayBoardError> {
+        service.updateReminder(edit)
+    }
     
     func toggle(id: String) async -> Result<Void, TodayBoardError> {
         service.toggleReminder(id: id)

--- a/HaruView/Data/EventKitService.swift
+++ b/HaruView/Data/EventKitService.swift
@@ -118,6 +118,27 @@ final class EventKitService {
             return .failure(.saveFailed)
         }
     }
+
+    func updateReminder(_ edit: ReminderEdit) -> Result<Void, TodayBoardError> {
+        guard let reminder = store.calendarItem(withIdentifier: edit.id) as? EKReminder else {
+            return .failure(.notFound)
+        }
+        reminder.title = edit.title
+        reminder.dueDateComponents = nil
+        if let due = edit.due {
+            if edit.includesTime {
+                reminder.dueDateComponents = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: due)
+            } else {
+                reminder.dueDateComponents = Calendar.current.dateComponents([.year, .month, .day], from: due)
+            }
+        }
+        do {
+            try store.save(reminder, commit: true)
+            return .success(())
+        } catch {
+            return .failure(.saveFailed)
+        }
+    }
     
     func toggleReminder(id: String) -> Result<Void, TodayBoardError> {
         guard let reminder = store.calendarItem(withIdentifier: id) as? EKReminder else {

--- a/HaruView/Domain/RepositoryProtocols.swift
+++ b/HaruView/Domain/RepositoryProtocols.swift
@@ -18,6 +18,7 @@ protocol EventRepositoryProtocol {
 protocol ReminderRepositoryProtocol {
     func fetchReminder() async -> Result<[Reminder], TodayBoardError>
     func add(_ input: ReminderInput) async -> Result<Void, TodayBoardError>
+    func update(_ edit: ReminderEdit) async -> Result<Void, TodayBoardError>
     func toggle(id: String) async -> Result<Void, TodayBoardError>
     func deleteReminder(id: String) async -> Result<Void, TodayBoardError>
 }
@@ -47,6 +48,8 @@ struct ReminderInput {
 }
 
 struct ReminderEdit {
+    let id: String
     let title: String
     let due: Date?
+    let includesTime: Bool
 }

--- a/HaruView/Domain/UseCases.swift
+++ b/HaruView/Domain/UseCases.swift
@@ -78,6 +78,19 @@ struct AddReminderUseCase {
     }
 }
 
+/// 미리알림 수정 유스케이스
+struct EditReminderUseCase {
+    private let repo: ReminderRepositoryProtocol
+
+    init(repo: ReminderRepositoryProtocol) {
+        self.repo = repo
+    }
+
+    func callAsFunction(_ edit: ReminderEdit) async -> Result<Void, TodayBoardError> {
+        await repo.update(edit)
+    }
+}
+
 struct FetchTodayWeatherUseCase {
     private let repo: WeatherRepositoryProtocol
     

--- a/HaruView/Localizable.xcstrings
+++ b/HaruView/Localizable.xcstrings
@@ -15,6 +15,7 @@
       }
     },
     "%@ 추가" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -398,6 +399,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Both calendar and reminder permissions are required."
+          }
+        }
+      }
+    },
+    "편집" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit"
           }
         }
       }

--- a/HaruView/Presentation/AddSheet.swift
+++ b/HaruView/Presentation/AddSheet.swift
@@ -275,7 +275,8 @@ struct AddSheet<VM: AddSheetViewModelProtocol>: View {
     
     private var toolbarTitle: some ToolbarContent {
         ToolbarItem(placement: .principal) {
-            Text(String(format: NSLocalizedString("%@ 추가", comment: ""), selected.localized))
+            let key = vm.isEdit ? "%@ 편집" : "%@ 추가"
+            Text(String(format: NSLocalizedString(key, comment: ""), selected.localized))
         }
     }
 }

--- a/HaruView/Presentation/AddSheet.swift
+++ b/HaruView/Presentation/AddSheet.swift
@@ -314,6 +314,8 @@ private struct HaruToggleStyle: ToggleStyle {
 
 #if DEBUG
 private class MockAddVM: AddSheetViewModelProtocol {
+    var isEdit: Bool = false
+    
     var currentTitle: String = ""
     
     

--- a/HaruView/Presentation/AddSheet.swift
+++ b/HaruView/Presentation/AddSheet.swift
@@ -29,13 +29,22 @@ struct AddSheet<VM: AddSheetViewModelProtocol>: View {
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
-                headerFilterView
-                TabView(selection: $selected) {
-                    eventPage.tag(AddSheetMode.event)
-                    reminderPage.tag(AddSheetMode.reminder)
+                if !vm.isEdit { headerFilterView }
+
+                if vm.isEdit {
+                    if vm.mode == .event {
+                        eventPage
+                    } else {
+                        reminderPage
+                    }
+                } else {
+                    TabView(selection: $selected) {
+                        eventPage.tag(AddSheetMode.event)
+                        reminderPage.tag(AddSheetMode.reminder)
+                    }
+                    .tabViewStyle(.page(indexDisplayMode: .never))
+                    .onChange(of: selected) { _, newValue in vm.mode = newValue }
                 }
-                .tabViewStyle(.page(indexDisplayMode: .never))
-                .onChange(of: selected) { _, newValue in vm.mode = newValue }
             }
             .background(Color(hexCode: "FFFCF5"))
             .toolbar { leadingToolbar; toolbarTitle; saveToolbar }
@@ -276,7 +285,7 @@ struct AddSheet<VM: AddSheetViewModelProtocol>: View {
     private var toolbarTitle: some ToolbarContent {
         ToolbarItem(placement: .principal) {
             let key = vm.isEdit ? "%@ 편집" : "%@ 추가"
-            Text(String(format: NSLocalizedString(key, comment: ""), selected.localized))
+            Text(String(format: NSLocalizedString(key, comment: ""), vm.mode.localized))
         }
     }
 }

--- a/HaruView/Presentation/AddSheet.swift
+++ b/HaruView/Presentation/AddSheet.swift
@@ -49,10 +49,10 @@ struct AddSheet<VM: AddSheetViewModelProtocol>: View {
             .background(Color(hexCode: "FFFCF5"))
             .toolbar { leadingToolbar; toolbarTitle; saveToolbar }
             .navigationBarTitleDisplayMode(.inline)
-            .confirmationDialog("작성 내용이 저장되지 않습니다.",
+            .confirmationDialog(vm.isEdit ? "변경사항을 저장하지 않을까요?" : "작성 내용이 저장되지 않습니다.",
                                 isPresented: $showDiscardAlert) {
-                Button("저장 안 하고 닫기", role: .destructive) { dismiss() }
-                Button("계속 작성", role: .cancel) {}
+                Button(vm.isEdit ? "변경사항 저장 안 하고 닫기" : "저장 안 하고 닫기", role: .destructive) { dismiss() }
+                Button(vm.isEdit ? "계속 편집" : "계속 작성", role: .cancel) {}
             }
         }
         .interactiveDismissDisabled(isDirty || vm.isSaving)
@@ -64,7 +64,7 @@ struct AddSheet<VM: AddSheetViewModelProtocol>: View {
 
     // MARK: Dirty Check
     private var isDirty: Bool {
-        !vm.currentTitle.isEmpty || (vm.mode == .event && vm.startDate > Date())
+        vm.hasChanges
     }
 
     // MARK: Header -----------------------------------------------------------
@@ -314,7 +314,9 @@ private struct HaruToggleStyle: ToggleStyle {
 
 #if DEBUG
 private class MockAddVM: AddSheetViewModelProtocol {
-    var isEdit: Bool = false
+    var isEdit: Bool { false }
+    var hasChanges: Bool { true }
+
     
     var currentTitle: String = ""
     

--- a/HaruView/Presentation/AddSheetViewModel.swift
+++ b/HaruView/Presentation/AddSheetViewModel.swift
@@ -28,6 +28,7 @@ protocol AddSheetViewModelProtocol: ObservableObject {
 
     var error: TodayBoardError? { get }
     var isSaving: Bool { get }
+    var isEdit: Bool { get }
 
     func save() async
 }
@@ -72,6 +73,7 @@ final class AddSheetViewModel: ObservableObject, @preconcurrency AddSheetViewMod
 
     @Published var error: TodayBoardError?
     @Published var isSaving: Bool = false
+    var isEdit: Bool { false }
 
     private var titles: [AddSheetMode:String] = [.event:"", .reminder:""]
 

--- a/HaruView/Presentation/AddSheetViewModel.swift
+++ b/HaruView/Presentation/AddSheetViewModel.swift
@@ -29,6 +29,7 @@ protocol AddSheetViewModelProtocol: ObservableObject {
     var error: TodayBoardError? { get }
     var isSaving: Bool { get }
     var isEdit: Bool { get }
+    var hasChanges: Bool { get }
 
     func save() async
 }
@@ -74,6 +75,9 @@ final class AddSheetViewModel: ObservableObject, @preconcurrency AddSheetViewMod
     @Published var error: TodayBoardError?
     @Published var isSaving: Bool = false
     var isEdit: Bool { false }
+    var hasChanges: Bool {
+        !currentTitle.isEmpty || (mode == .event && startDate > Date())
+    }
 
     private var titles: [AddSheetMode:String] = [.event:"", .reminder:""]
 

--- a/HaruView/Presentation/EditSheetViewModel.swift
+++ b/HaruView/Presentation/EditSheetViewModel.swift
@@ -1,0 +1,87 @@
+//
+//  EditSheetViewModel.swift
+//  HaruView
+//
+//  Created by Codex on 2024.
+//
+
+import SwiftUI
+
+@MainActor
+final class EditSheetViewModel: ObservableObject, @preconcurrency AddSheetViewModelProtocol {
+    @Published var mode: AddSheetMode = .event { didSet { currentTitle = titles[mode] ?? "" } }
+    @Published var currentTitle: String = "" { didSet { titles[mode] = currentTitle } }
+    @Published var startDate: Date = .now { didSet { clampEndIfNeeded() } }
+    @Published var endDate: Date = Calendar.current.date(byAdding: .hour, value: 1, to: .now)!
+    @Published var dueDate: Date = .now
+    @Published var isAllDay: Bool = false
+    @Published var includeTime: Bool = true
+    @Published var error: TodayBoardError?
+    @Published var isSaving: Bool = false
+
+    var isEdit: Bool { true }
+
+    private var titles: [AddSheetMode:String] = [.event:"", .reminder:""]
+
+    private let editEvent: EditEventUseCase
+    private let editReminder: EditReminderUseCase
+    private let objectId: String
+
+    init(event: Event, editEvent: EditEventUseCase, editReminder: EditReminderUseCase) {
+        self.editEvent = editEvent
+        self.editReminder = editReminder
+        self.objectId = event.id
+        self.mode = .event
+        self.currentTitle = event.title
+        self.startDate = event.start
+        self.endDate = event.end
+        let cal = Calendar.current
+        let compsStart = cal.dateComponents([.hour, .minute], from: event.start)
+        let compsEnd = cal.dateComponents([.hour, .minute], from: event.end)
+        if cal.isDate(event.start, inSameDayAs: event.end) && compsStart.hour == 0 && compsStart.minute == 0 && compsEnd.hour == 23 && compsEnd.minute == 59 {
+            self.isAllDay = true
+        }
+        titles[.event] = event.title
+    }
+
+    init(reminder: Reminder, editEvent: EditEventUseCase, editReminder: EditReminderUseCase) {
+        self.editEvent = editEvent
+        self.editReminder = editReminder
+        self.objectId = reminder.id
+        self.mode = .reminder
+        self.currentTitle = reminder.title
+        if let due = reminder.due { self.dueDate = due }
+        self.includeTime = reminder.due != nil
+        titles[.reminder] = reminder.title
+    }
+
+    func save() async {
+        isSaving = true
+        error = nil
+
+        if mode == .event { clampEndIfNeeded() }
+
+        switch mode {
+        case .event:
+            let res = await editEvent(.init(id: objectId, title: titles[.event] ?? "", start: startDate, end: endDate))
+            handle(res)
+        case .reminder:
+            let res = await editReminder(.init(id: objectId, title: titles[.reminder] ?? "", due: dueDate, includesTime: includeTime))
+            handle(res)
+        }
+        isSaving = false
+    }
+
+    private func clampEndIfNeeded() {
+        guard !isAllDay else { return }
+        let minInterval: TimeInterval = 60
+        if endDate < startDate.addingTimeInterval(minInterval) {
+            endDate = startDate.addingTimeInterval(minInterval)
+        }
+    }
+
+    private func handle(_ result: Result<Void, TodayBoardError>) {
+        if case .failure(let err) = result { self.error = err }
+    }
+}
+

--- a/HaruView/Presentation/EventListSheet.swift
+++ b/HaruView/Presentation/EventListSheet.swift
@@ -10,7 +10,9 @@ import SwiftUI
 struct EventListSheet<VM: EventListViewModelProtocol>: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.scenePhase) private var phase
+    @Environment(\.di) private var di
     @StateObject var vm: VM
+    @State private var editingEvent: Event?
     
     init(vm: VM) {
         _vm = StateObject(wrappedValue: vm)
@@ -23,6 +25,15 @@ struct EventListSheet<VM: EventListViewModelProtocol>: View {
                     ForEach(vm.events) { event in
                         EventCard(event: event)
                             .contextMenu {
+                                Button {
+                                    editingEvent = event
+                                } label: {
+                                    Label {
+                                        Text("편집").font(Font.pretendardRegular(size: 14))
+                                    } icon: {
+                                        Image(systemName: "pencil")
+                                    }
+                                }
                                 Button(role: .destructive) {
                                     Task {
                                         await vm.delete(id: event.id)
@@ -50,6 +61,11 @@ struct EventListSheet<VM: EventListViewModelProtocol>: View {
             if phase == .active { vm.refresh() }
         }
         .refreshable { vm.refresh() }
+        .sheet(item: $editingEvent) { event in
+            AddSheet(vm: di.makeEditSheetVM(event: event)) {
+                vm.refresh()
+            }
+        }
     }
     
     private var navigationTitleView: some ToolbarContent {

--- a/HaruView/Presentation/EventListSheet.swift
+++ b/HaruView/Presentation/EventListSheet.swift
@@ -13,6 +13,7 @@ struct EventListSheet<VM: EventListViewModelProtocol>: View {
     @Environment(\.di) private var di
     @StateObject var vm: VM
     @State private var editingEvent: Event?
+    @State private var showToast: Bool = false
     
     init(vm: VM) {
         _vm = StateObject(wrappedValue: vm)
@@ -64,9 +65,28 @@ struct EventListSheet<VM: EventListViewModelProtocol>: View {
         .sheet(item: $editingEvent) { event in
             AddSheet(vm: di.makeEditSheetVM(event: event)) {
                 vm.refresh()
+                showToast = true
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2) { showToast = false }
             }
         }
+        .overlay(alignment: .top) {
+            if showToast { ToastView().transition(.opacity) }
+        }
     }
+
+private struct ToastView: View {
+    var body: some View {
+        Text("저장이 완료되었습니다.")
+            .font(.pretendardSemiBold(size: 14))
+            .foregroundStyle(Color.white)
+            .padding(10)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .opacity(0.85)
+            )
+            .transition(.move(edge: .top).combined(with: .opacity))
+    }
+}
     
     private var navigationTitleView: some ToolbarContent {
         ToolbarItem(placement: .principal) {

--- a/HaruView/Presentation/HomeView.swift
+++ b/HaruView/Presentation/HomeView.swift
@@ -20,6 +20,8 @@ struct HomeView<VM: HomeViewModelProtocol>: View {
     @State private var showEventSheet: Bool = false
     @State private var showReminderSheet: Bool = false
     @State private var showAddSheet: Bool = false
+    @State private var editingEvent: Event?
+    @State private var editingReminder: Reminder?
     @State private var showToast: Bool = false
     @State private var adHeight: CGFloat = 0
     
@@ -68,6 +70,16 @@ struct HomeView<VM: HomeViewModelProtocol>: View {
                                 }
                             }
                             .onDisappear { vm.refresh(.storeChange) }
+                        }
+                        .sheet(item: $editingEvent) { event in
+                            AddSheet(vm: di.makeEditSheetVM(event: event)) {
+                                vm.refresh(.storeChange)
+                            }
+                        }
+                        .sheet(item: $editingReminder) { rem in
+                            AddSheet(vm: di.makeEditSheetVM(reminder: rem)) {
+                                vm.refresh(.storeChange)
+                            }
                         }
                     
                     
@@ -189,6 +201,15 @@ struct HomeView<VM: HomeViewModelProtocol>: View {
                 ForEach(vm.state.overview.events.prefix(5)) { event in
                     EventCard(event: event)
                         .contextMenu {
+                            Button {
+                                editingEvent = event
+                            } label: {
+                                Label {
+                                    Text("편집").font(Font.pretendardRegular(size: 14))
+                                } icon: {
+                                    Image(systemName: "pencil")
+                                }
+                            }
                             Button(role: .destructive) {
                                 Task {
                                     await vm.deleteObject(.event(event.id))
@@ -236,6 +257,16 @@ struct HomeView<VM: HomeViewModelProtocol>: View {
                         Task { await vm.toggleReminder(id: rem.id) }
                     }
                     .contextMenu {
+                        Button {
+                            editingReminder = rem
+                        } label: {
+                            Label {
+                                Text("편집")
+                                    .font(Font.pretendardRegular(size: 14))
+                            } icon: {
+                                Image(systemName: "pencil")
+                            }
+                        }
                         Button(role: .destructive) {
                             Task {
                                 await vm.deleteObject(.reminder(rem.id))

--- a/HaruView/Presentation/HomeView.swift
+++ b/HaruView/Presentation/HomeView.swift
@@ -74,11 +74,19 @@ struct HomeView<VM: HomeViewModelProtocol>: View {
                         .sheet(item: $editingEvent) { event in
                             AddSheet(vm: di.makeEditSheetVM(event: event)) {
                                 vm.refresh(.storeChange)
+                                showToast = true
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                                    showToast = false
+                                }
                             }
                         }
                         .sheet(item: $editingReminder) { rem in
                             AddSheet(vm: di.makeEditSheetVM(reminder: rem)) {
                                 vm.refresh(.storeChange)
+                                showToast = true
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                                    showToast = false
+                                }
                             }
                         }
                     

--- a/HaruView/Presentation/ReminderListSheet.swift
+++ b/HaruView/Presentation/ReminderListSheet.swift
@@ -13,6 +13,7 @@ struct ReminderListSheet<VM: ReminderListViewModelProtocol>: View {
     @Environment(\.di) private var di
     @StateObject var vm: VM
     @State private var editingReminder: Reminder?
+    @State private var showToast: Bool = false
     
     init(vm: VM) {
         _vm = StateObject(wrappedValue: vm)
@@ -72,7 +73,12 @@ struct ReminderListSheet<VM: ReminderListViewModelProtocol>: View {
         .sheet(item: $editingReminder) { rem in
             AddSheet(vm: di.makeEditSheetVM(reminder: rem)) {
                 vm.refresh()
+                showToast = true
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2) { showToast = false }
             }
+        }
+        .overlay(alignment: .top) {
+            if showToast { ToastView().transition(.opacity) }
         }
     }
     
@@ -93,6 +99,20 @@ struct ReminderListSheet<VM: ReminderListViewModelProtocol>: View {
                     .foregroundStyle(Color(hexCode: "A76545"))
             }
         }
+    }
+}
+
+private struct ToastView: View {
+    var body: some View {
+        Text("저장이 완료되었습니다.")
+            .font(.pretendardSemiBold(size: 14))
+            .foregroundStyle(Color.white)
+            .padding(10)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .opacity(0.85)
+            )
+            .transition(.move(edge: .top).combined(with: .opacity))
     }
 }
 

--- a/HaruView/Presentation/ReminderListSheet.swift
+++ b/HaruView/Presentation/ReminderListSheet.swift
@@ -10,7 +10,9 @@ import SwiftUI
 struct ReminderListSheet<VM: ReminderListViewModelProtocol>: View {
     @Environment(\.scenePhase) private var phase
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.di) private var di
     @StateObject var vm: VM
+    @State private var editingReminder: Reminder?
     
     init(vm: VM) {
         _vm = StateObject(wrappedValue: vm)
@@ -27,6 +29,15 @@ struct ReminderListSheet<VM: ReminderListViewModelProtocol>: View {
                             }
                         }
                         .contextMenu {
+                            Button {
+                                editingReminder = reminder
+                            } label: {
+                                Label {
+                                    Text("편집").font(Font.pretendardRegular(size: 14))
+                                } icon: {
+                                    Image(systemName: "pencil")
+                                }
+                            }
                             Button(role: .destructive) {
                                 Task {
                                     await vm.delete(id: reminder.id)
@@ -58,6 +69,11 @@ struct ReminderListSheet<VM: ReminderListViewModelProtocol>: View {
             if phase == .active { vm.refresh() }
         }
         .refreshable { vm.refresh() }
+        .sheet(item: $editingReminder) { rem in
+            AddSheet(vm: di.makeEditSheetVM(reminder: rem)) {
+                vm.refresh()
+            }
+        }
     }
     
     private var navigationTitleView: some ToolbarContent {


### PR DESCRIPTION
## Summary
- allow repositories to update reminders and introduce `EditReminderUseCase`
- support editing reminders in `EventKitService` and repository
- expose edit use cases and view models through `AppDI`
- create `EditSheetViewModel` and use it from home and list views
- show edit buttons and sheet for events and reminders
- update sheet title depending on add or edit mode

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684da06e84a08329a74ca042ecd60a59